### PR TITLE
fix: use process.env.NODE_ENV

### DIFF
--- a/packages/vue-cli-plugin-mpx-mp/config/base.js
+++ b/packages/vue-cli-plugin-mpx-mp/config/base.js
@@ -42,9 +42,7 @@ module.exports = function resolveMpBaseWebpackConfig (api, options) {
 
   webpackConfig.plugin('mpx-define-plugin').use(webpack.DefinePlugin, [
     {
-      'process.env': {
-        NODE_ENV: `"${process.env.NODE_ENV}"`
-      }
+      'process.env.NODE_ENV': `"${process.env.NODE_ENV}"`
     }
   ])
   webpackConfig.mode('development').context(api.service.context)


### PR DESCRIPTION
使用process.env.NODE_ENV而不是process.env = { NODE_ENV : ""} 以避免覆盖其它的配置
https://webpack.docschina.org/plugins/define-plugin#usage