### PR TITLE
feat: 依赖&tsconfig

### DIFF
--- a/packages/vue-cli-plugin-mpx-e2e-test/generator/index.js
+++ b/packages/vue-cli-plugin-mpx-e2e-test/generator/index.js
@@ -7,13 +7,6 @@ module.exports = function (api, options = {}) {
     }
   })
 
-  api.extendPackage({
-    devDependencies: {
-      jest: '^27.4.5',
-      '@types/jest': '^27.5.1'
-    }
-  })
-
   if (needTs) {
     api.extendPackage({
       devDependencies: {

--- a/packages/vue-cli-plugin-mpx-e2e-test/package.json
+++ b/packages/vue-cli-plugin-mpx-e2e-test/package.json
@@ -9,7 +9,9 @@
   "dependencies": {
     "@mpxjs/e2e": "^0.0.11",
     "@mpxjs/e2e-scripts": "^0.0.9",
-    "miniprogram-automator": "^0.10.0"
+    "miniprogram-automator": "^0.10.0",
+    "jest": "^27.4.5",
+    "@types/jest": "^27.5.1"
   },
   "keywords": [],
   "author": "",

--- a/packages/vue-cli-plugin-mpx-typescript/generator/template-tsconfig/tsconfig.json
+++ b/packages/vue-cli-plugin-mpx-typescript/generator/template-tsconfig/tsconfig.json
@@ -12,9 +12,8 @@
     ],
     "types": [
       <%_ if(needTest) { _%>
-      "jest",
+      "jest"
       <%_ } _%>
-      "@mpxjs/core"
     ]
   },
   "exclude": [

--- a/packages/vue-cli-plugin-mpx-unit-test/generator/index.js
+++ b/packages/vue-cli-plugin-mpx-unit-test/generator/index.js
@@ -6,15 +6,6 @@ module.exports = function (api, options = {}) {
     }
   })
 
-  api.extendPackage({
-    devDependencies: {
-      '@mpxjs/mpx-jest': '^0.0.9',
-      '@mpxjs/miniprogram-simulate': '^1.4.8',
-      'babel-jest': '^25.3.0',
-      jest: '^24.9.0'
-    }
-  })
-
   if (needTs) {
     api.extendPackage({
       devDependencies: {

--- a/packages/vue-cli-plugin-mpx-unit-test/package.json
+++ b/packages/vue-cli-plugin-mpx-unit-test/package.json
@@ -12,5 +12,12 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
     "access": "public"
+  },
+  "dependencies": {
+    "@mpxjs/mpx-jest": "^0.0.9",
+    "@mpxjs/miniprogram-simulate": "^1.4.8",
+    "babel-jest": "^25.3.0",
+    "jest": "^27.4.5",
+    "@types/jest": "^27.5.1"
   }
 }


### PR DESCRIPTION
还是把依赖移到package.json比较合理吧，unit和e2e同时存在的话容易较低版本覆盖较高或者反之
以及下掉了 @mpxjs/core 的type