### PR TITLE
fix: cli依赖修复

### DIFF
--- a/packages/mpx-cli/package.json
+++ b/packages/mpx-cli/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@types/inquirer": "^8.1.3",
     "@vue/cli": "^5.0.0",
+    "@vue/cli-shared-utils": "^5.0.4",
     "commander": "^7.1.0",
     "fs-extra": "^9.1.0",
     "inquirer": "^8.0.0",

--- a/packages/vue-cli-plugin-mpx/config/base.js
+++ b/packages/vue-cli-plugin-mpx/config/base.js
@@ -20,7 +20,10 @@ const { getReporter } = require('../utils/reporter')
  * @param { string } name
  */
 function changeStyleVueRuleToMpx (config, name) {
+  // 移除vue-modules规则，因为mpx在构建时会在resourceQuery携带filename，这会导致带有
+  // module命名的mpx文件命中vue-modules规则，导致样式编译错误
   config.module.rule(name).oneOfs.delete('vue-modules')
+  // 抹平web和mp配置的命名，方便一次修改
   const store = config.module.rule(name).oneOfs.store
   const value = store.get('vue')
   value.name = 'mpx'

--- a/packages/vue-cli-plugin-mpx/config/base.js
+++ b/packages/vue-cli-plugin-mpx/config/base.js
@@ -20,6 +20,7 @@ const { getReporter } = require('../utils/reporter')
  * @param { string } name
  */
 function changeStyleVueRuleToMpx (config, name) {
+  config.module.rule(name).oneOfs.delete('vue-modules')
   const store = config.module.rule(name).oneOfs.store
   const value = store.get('vue')
   value.name = 'mpx'


### PR DESCRIPTION
修复mpx-cli的依赖，fix: https://github.com/didi/mpx/issues/1418
移除vue-modules的规则，防止带有module的mpx文件命名，css失效。