### PR TITLE
Add React Native sourcemap composition and middleware support

### DIFF
--- a/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
+++ b/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
@@ -171,8 +171,7 @@ describe('compose-mpx-sourcemap', () => {
     expect(metroMapping.name).toBe('init')
   })
 
-  test('keeps untraced app.js fallback mappings without warning when some mappings trace successfully', async () => {
-    const warnings = []
+  test('keeps untraced app.js fallback mappings when some mappings trace successfully', async () => {
     const mpxSource = 'webpack://app/src/pages/index.mpx'
     const appSource = '/project/ReactNativeProject/app.js'
     const metroMap = createMap({
@@ -213,11 +212,9 @@ describe('compose-mpx-sourcemap', () => {
     const composedMap = await composeMpxSourceMap({
       metroMap,
       mpxMap,
-      generatedSource: 'app.js',
-      onWarn: (message) => warnings.push(message)
+      generatedSource: 'app.js'
     })
 
-    expect(warnings).toEqual([])
     const tracedMapping = await generatedMappingForLine(composedMap, 1)
     expect(tracedMapping.source).toBe(mpxSource)
     expect(tracedMapping.originalLine).toBe(8)

--- a/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
+++ b/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
@@ -1,5 +1,6 @@
 const os = require('os')
 const path = require('path')
+const { Buffer } = require('buffer')
 const fs = require('fs-extra')
 const execa = require('execa')
 const { SourceMapConsumer, SourceMapGenerator } = require('source-map')
@@ -8,8 +9,12 @@ const {
   composeMpxSourceMapFiles
 } = require('../lib/rn/compose-mpx-sourcemap')
 const {
+  createMpxSourcemapMiddleware
+} = require('../lib/rn/metro-mpx-sourcemap-middleware')
+const {
   applyRnPackageConfig,
-  copyRnSourcemapScript
+  copyRnSourcemapScript,
+  writeRnMetroConfig
 } = require('../lib/createRn')
 
 function createMap ({ file, mappings, sourcesContent = {} }) {
@@ -43,6 +48,61 @@ async function generatedMappingForLine (map, line) {
       }
     })
     return result
+  })
+}
+
+function writeMapFile (filePath, map) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, JSON.stringify(map), 'utf8')
+}
+
+function runMiddlewareRequest ({ url, method = 'GET', body, mpxMapPath, warn = function () {}, contentType = 'application/json' }) {
+  return new Promise((resolve, reject) => {
+    const middleware = (req, res) => {
+      res.setHeader('Content-Type', contentType)
+      res.setHeader('Content-Length', Buffer.byteLength(body))
+      res.end(body)
+    }
+    const enhancedMiddleware = createMpxSourcemapMiddleware({ mpxMapPath, warn })(middleware)
+    const chunks = []
+    const headers = {}
+    const res = {
+      statusCode: 200,
+      setHeader (name, value) {
+        headers[name.toLowerCase()] = String(value)
+      },
+      getHeader (name) {
+        return headers[name.toLowerCase()]
+      },
+      removeHeader (name) {
+        delete headers[name.toLowerCase()]
+      },
+      writeHead (statusCode, nextHeaders) {
+        this.statusCode = statusCode
+        Object.keys(nextHeaders || {}).forEach((name) => {
+          this.setHeader(name, nextHeaders[name])
+        })
+      },
+      write (chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)))
+      },
+      end (chunk) {
+        if (chunk) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)))
+        }
+        resolve({
+          body: Buffer.concat(chunks).toString(),
+          headers,
+          statusCode: this.statusCode
+        })
+      }
+    }
+
+    try {
+      enhancedMiddleware({ method, url }, res, reject)
+    } catch (error) {
+      reject(error)
+    }
   })
 }
 
@@ -176,6 +236,220 @@ describe('compose-mpx-sourcemap', () => {
   })
 })
 
+describe('metro-mpx-sourcemap-middleware', () => {
+  test('composes Metro .map responses with the latest Mpx app.js.map', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mpx-rn-dev-map-'))
+    const mpxMapPath = path.join(tempDir, 'app.js.map')
+    const metroOnlySource = 'node_modules/react-native/index.js'
+    const mpxSource = 'src/pages/index.mpx'
+    const metroMap = createMap({
+      file: 'index.bundle',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 1, column: 0 },
+          source: path.join(tempDir, 'app.js')
+        },
+        {
+          generated: { line: 2, column: 0 },
+          original: { line: 4, column: 1 },
+          source: metroOnlySource
+        }
+      ],
+      sourcesContent: {
+        [path.join(tempDir, 'app.js')]: 'require("./app")',
+        [metroOnlySource]: 'module.exports = require("react-native")'
+      }
+    })
+    const mpxMap = createMap({
+      file: 'app.js',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 7, column: 3 },
+          source: mpxSource
+        }
+      ],
+      sourcesContent: {
+        [mpxSource]: '<template><view /></template>'
+      }
+    })
+    writeMapFile(mpxMapPath, mpxMap)
+
+    const result = await runMiddlewareRequest({
+      url: '/index.bundle.map?platform=ios&dev=true',
+      body: JSON.stringify(metroMap),
+      mpxMapPath
+    })
+    const composedMap = JSON.parse(result.body)
+
+    expect(composedMap.sources).toContain(mpxSource)
+    expect(composedMap.sources).toContain(metroOnlySource)
+    expect(composedMap.sources).not.toContain(path.join(tempDir, 'app.js'))
+    expect(result.headers['content-type']).toBe('application/json')
+    expect(Number(result.headers['content-length'])).toBe(Buffer.byteLength(result.body))
+  })
+
+  test('passes through non sourcemap requests unchanged', async () => {
+    const body = 'console.log("bundle")'
+    const result = await runMiddlewareRequest({
+      url: '/index.bundle?platform=ios&dev=true',
+      body,
+      mpxMapPath: path.resolve(__dirname, 'missing-app.js.map'),
+      contentType: 'application/javascript'
+    })
+
+    expect(result.body).toBe(body)
+    expect(result.headers['content-type']).toBe('application/javascript')
+  })
+
+  test('returns original Metro map and warns when app.js.map cannot be read', async () => {
+    const warnings = []
+    const metroMap = createMap({
+      file: 'index.bundle',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 1, column: 0 },
+          source: 'app.js'
+        }
+      ]
+    })
+
+    const result = await runMiddlewareRequest({
+      url: '/index.bundle.map?platform=android&dev=true',
+      body: JSON.stringify(metroMap),
+      mpxMapPath: path.resolve(__dirname, 'missing-app.js.map'),
+      warn: (message) => warnings.push(message)
+    })
+
+    expect(JSON.parse(result.body).sources).toEqual(metroMap.sources)
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toMatch(/Mpx sourcemap not found/)
+  })
+
+  test('returns original Metro map and warns when app.js.map is invalid', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mpx-rn-invalid-map-'))
+    const mpxMapPath = path.join(tempDir, 'app.js.map')
+    const warnings = []
+    const metroMap = createMap({
+      file: 'index.bundle',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 1, column: 0 },
+          source: 'app.js'
+        }
+      ]
+    })
+    fs.writeFileSync(mpxMapPath, '{ invalid', 'utf8')
+
+    const result = await runMiddlewareRequest({
+      url: '/index.bundle.map?platform=android&dev=true',
+      body: JSON.stringify(metroMap),
+      mpxMapPath,
+      warn: (message) => warnings.push(message)
+    })
+
+    expect(JSON.parse(result.body).sources).toEqual(metroMap.sources)
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toMatch(/Failed to parse Mpx sourcemap/)
+  })
+
+  test('returns original Metro map and warns when Metro map response is invalid', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mpx-rn-invalid-response-'))
+    const mpxMapPath = path.join(tempDir, 'app.js.map')
+    const warnings = []
+    const mpxMap = createMap({
+      file: 'app.js',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 1, column: 0 },
+          source: 'src/app.mpx'
+        }
+      ]
+    })
+    writeMapFile(mpxMapPath, mpxMap)
+
+    const result = await runMiddlewareRequest({
+      url: '/index.bundle.map?platform=ios&dev=true',
+      body: '{ invalid',
+      mpxMapPath,
+      warn: (message) => warnings.push(message)
+    })
+
+    expect(result.body).toBe('{ invalid')
+    expect(warnings.length).toBe(1)
+  })
+
+  test('rewrites app.js symbolicated frames to original Mpx source frames', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mpx-rn-symbolicate-'))
+    const mpxMapPath = path.join(tempDir, 'app.js.map')
+    const mpxSource = 'src/pages/index.mpx'
+    const mpxMap = createMap({
+      file: 'app.js',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 9, column: 4 },
+          source: mpxSource,
+          name: 'mounted'
+        }
+      ]
+    })
+    writeMapFile(mpxMapPath, mpxMap)
+
+    const result = await runMiddlewareRequest({
+      url: '/symbolicate',
+      method: 'POST',
+      body: JSON.stringify({
+        symbolicatedStack: [
+          {
+            file: path.join(tempDir, 'app.js'),
+            lineNumber: 1,
+            column: 0,
+            methodName: 'render'
+          },
+          {
+            file: path.join(tempDir, 'app.js'),
+            lineNumber: 99,
+            column: 0,
+            methodName: 'unmapped'
+          },
+          {
+            file: 'node_modules/react-native/index.js',
+            lineNumber: 2,
+            column: 1,
+            methodName: 'require'
+          }
+        ]
+      }),
+      mpxMapPath
+    })
+    const symbolicated = JSON.parse(result.body)
+
+    expect(symbolicated.symbolicatedStack[0]).toMatchObject({
+      file: mpxSource,
+      lineNumber: 9,
+      column: 4,
+      methodName: 'mounted'
+    })
+    expect(symbolicated.symbolicatedStack[1]).toMatchObject({
+      file: path.join(tempDir, 'app.js'),
+      lineNumber: 99,
+      column: 0,
+      methodName: 'unmapped'
+    })
+    expect(symbolicated.symbolicatedStack[2]).toMatchObject({
+      file: 'node_modules/react-native/index.js',
+      lineNumber: 2,
+      column: 1,
+      methodName: 'require'
+    })
+  })
+})
+
 describe('RN project sourcemap generation config', () => {
   test('adds sourcemap dependencies and bundle scripts to RN package.json', () => {
     const pkg = {
@@ -200,7 +474,21 @@ describe('RN project sourcemap generation config', () => {
     copyRnSourcemapScript(tempDir)
 
     const targetPath = path.join(tempDir, 'scripts/compose-mpx-sourcemap.js')
+    const middlewarePath = path.join(tempDir, 'scripts/metro-mpx-sourcemap-middleware.js')
     expect(fs.existsSync(targetPath)).toBe(true)
+    expect(fs.existsSync(middlewarePath)).toBe(true)
     expect(fs.readFileSync(targetPath, 'utf8')).toContain('composeMpxSourceMap')
+    expect(fs.readFileSync(middlewarePath, 'utf8')).toContain('enhanceMiddleware')
+  })
+
+  test('writes metro config with Mpx sourcemap middleware enabled', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mpx-rn-metro-config-'))
+
+    writeRnMetroConfig(tempDir)
+
+    const metroConfigPath = path.join(tempDir, 'metro.config.js')
+    const metroConfig = fs.readFileSync(metroConfigPath, 'utf8')
+    expect(metroConfig).toContain("require('./scripts/metro-mpx-sourcemap-middleware')")
+    expect(metroConfig).toContain('enhanceMiddleware')
   })
 })

--- a/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
+++ b/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
@@ -1,0 +1,206 @@
+const os = require('os')
+const path = require('path')
+const fs = require('fs-extra')
+const execa = require('execa')
+const { SourceMapConsumer, SourceMapGenerator } = require('source-map')
+const {
+  composeMpxSourceMap,
+  composeMpxSourceMapFiles
+} = require('../lib/rn/compose-mpx-sourcemap')
+const {
+  applyRnPackageConfig,
+  copyRnSourcemapScript
+} = require('../lib/createRn')
+
+function createMap ({ file, mappings, sourcesContent = {} }) {
+  const generator = new SourceMapGenerator({ file })
+  mappings.forEach((mapping) => {
+    generator.addMapping(mapping)
+  })
+  Object.keys(sourcesContent).forEach((source) => {
+    generator.setSourceContent(source, sourcesContent[source])
+  })
+  return generator.toJSON()
+}
+
+async function withConsumer (map, cb) {
+  const consumer = await new SourceMapConsumer(map)
+  try {
+    return cb(consumer)
+  } finally {
+    if (consumer.destroy) {
+      consumer.destroy()
+    }
+  }
+}
+
+async function generatedMappingForLine (map, line) {
+  return withConsumer(map, (consumer) => {
+    let result
+    consumer.eachMapping((mapping) => {
+      if (mapping.generatedLine === line && mapping.generatedColumn === 0) {
+        result = mapping
+      }
+    })
+    return result
+  })
+}
+
+describe('compose-mpx-sourcemap', () => {
+  test('traces Metro app.js mappings back to original Mpx sources only', async () => {
+    const metroOnlySource = 'node_modules/react-native/Libraries/Core/InitializeCore.js'
+    const mpxSource = 'webpack://app/src/pages/index.mpx'
+    const metroMap = createMap({
+      file: 'main.jsbundle',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 1, column: 0 },
+          source: '/project/ReactNativeProject/app.js',
+          name: 'render'
+        },
+        {
+          generated: { line: 2, column: 0 },
+          original: { line: 3, column: 4 },
+          source: metroOnlySource,
+          name: 'init'
+        }
+      ],
+      sourcesContent: {
+        '/project/ReactNativeProject/app.js': 'require("./app")',
+        [metroOnlySource]: 'InitializeCore();'
+      }
+    })
+    const mpxMap = createMap({
+      file: 'app.js',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 8, column: 2 },
+          source: mpxSource,
+          name: 'created'
+        }
+      ],
+      sourcesContent: {
+        [mpxSource]: '<template><view /></template>'
+      }
+    })
+
+    const composedMap = await composeMpxSourceMap({
+      metroMap,
+      mpxMap,
+      generatedSource: 'app.js'
+    })
+
+    expect(composedMap.sources).toContain(mpxSource)
+    expect(composedMap.sources).toContain(metroOnlySource)
+    expect(composedMap.sources).not.toContain('/project/ReactNativeProject/app.js')
+    expect(composedMap.sourcesContent[composedMap.sources.indexOf(mpxSource)]).toBe('<template><view /></template>')
+    expect(composedMap.sourcesContent[composedMap.sources.indexOf(metroOnlySource)]).toBe('InitializeCore();')
+
+    const mpxMapping = await generatedMappingForLine(composedMap, 1)
+    expect(mpxMapping.source).toBe(mpxSource)
+    expect(mpxMapping.originalLine).toBe(8)
+    expect(mpxMapping.originalColumn).toBe(2)
+    expect(mpxMapping.name).toBe('created')
+
+    const metroMapping = await generatedMappingForLine(composedMap, 2)
+    expect(metroMapping.source).toBe(metroOnlySource)
+    expect(metroMapping.originalLine).toBe(3)
+    expect(metroMapping.originalColumn).toBe(4)
+    expect(metroMapping.name).toBe('init')
+  })
+
+  test('fails when Metro map has no app.js mapping', async () => {
+    const metroMap = createMap({
+      file: 'main.jsbundle',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 1, column: 0 },
+          source: 'node_modules/react-native/index.js'
+        }
+      ]
+    })
+    const mpxMap = createMap({
+      file: 'app.js',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 1, column: 0 },
+          source: 'src/app.mpx'
+        }
+      ]
+    })
+
+    await expect(composeMpxSourceMap({
+      metroMap,
+      mpxMap,
+      generatedSource: 'app.js'
+    })).rejects.toThrow(/No Metro mappings matched app\.js/)
+  })
+
+  test('fails clearly for missing and invalid sourcemap files', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mpx-rn-sourcemap-'))
+    const metroMapPath = path.join(tempDir, 'metro.map')
+    const mpxMapPath = path.join(tempDir, 'app.js.map')
+    const outputPath = path.join(tempDir, 'out.map')
+
+    await expect(composeMpxSourceMapFiles({
+      metroMapPath,
+      mpxMapPath,
+      outputPath
+    })).rejects.toThrow(/Metro sourcemap not found/)
+
+    fs.writeFileSync(metroMapPath, '{ invalid', 'utf8')
+    fs.writeFileSync(mpxMapPath, '{}', 'utf8')
+
+    await expect(composeMpxSourceMapFiles({
+      metroMapPath,
+      mpxMapPath,
+      outputPath
+    })).rejects.toThrow(/Failed to parse Metro sourcemap/)
+  })
+
+  test('CLI exits non-zero when compose inputs are invalid', async () => {
+    const scriptPath = path.resolve(__dirname, '../lib/rn/compose-mpx-sourcemap.js')
+
+    await expect(execa.node(scriptPath, [
+      '--metro-map',
+      path.resolve(__dirname, 'missing-metro.map'),
+      '--mpx-map',
+      path.resolve(__dirname, 'missing-app.js.map')
+    ])).rejects.toMatchObject({
+      exitCode: 1
+    })
+  })
+})
+
+describe('RN project sourcemap generation config', () => {
+  test('adds sourcemap dependencies and bundle scripts to RN package.json', () => {
+    const pkg = {
+      dependencies: {},
+      devDependencies: {},
+      scripts: {}
+    }
+
+    applyRnPackageConfig(pkg)
+
+    expect(pkg.devDependencies).toHaveProperty('source-map', '^0.7.6')
+    expect(pkg.devDependencies).not.toHaveProperty('@jridgewell/remapping')
+    expect(pkg.scripts['bundle:ios']).toContain('--sourcemap-output ./ios/main.jsbundle.map')
+    expect(pkg.scripts['bundle:ios']).toContain('node ./scripts/compose-mpx-sourcemap.js')
+    expect(pkg.scripts['bundle:android']).toContain('--sourcemap-output android/app/src/main/assets/index.android.bundle.map')
+    expect(pkg.scripts['bundle:android']).toContain('node ./scripts/compose-mpx-sourcemap.js')
+  })
+
+  test('copies compose script into generated RN project', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mpx-rn-project-'))
+
+    copyRnSourcemapScript(tempDir)
+
+    const targetPath = path.join(tempDir, 'scripts/compose-mpx-sourcemap.js')
+    expect(fs.existsSync(targetPath)).toBe(true)
+    expect(fs.readFileSync(targetPath, 'utf8')).toContain('composeMpxSourceMap')
+  })
+})

--- a/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
+++ b/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
@@ -171,6 +171,65 @@ describe('compose-mpx-sourcemap', () => {
     expect(metroMapping.name).toBe('init')
   })
 
+  test('keeps untraced app.js fallback mappings without warning when some mappings trace successfully', async () => {
+    const warnings = []
+    const mpxSource = 'webpack://app/src/pages/index.mpx'
+    const appSource = '/project/ReactNativeProject/app.js'
+    const metroMap = createMap({
+      file: 'main.jsbundle',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 1, column: 10 },
+          source: appSource,
+          name: 'render'
+        },
+        {
+          generated: { line: 2, column: 0 },
+          original: { line: 1, column: 0 },
+          source: appSource,
+          name: 'bootstrap'
+        }
+      ],
+      sourcesContent: {
+        [appSource]: 'var context = this; render();'
+      }
+    })
+    const mpxMap = createMap({
+      file: 'app.js',
+      mappings: [
+        {
+          generated: { line: 1, column: 10 },
+          original: { line: 8, column: 2 },
+          source: mpxSource,
+          name: 'render'
+        }
+      ],
+      sourcesContent: {
+        [mpxSource]: '<template><view /></template>'
+      }
+    })
+
+    const composedMap = await composeMpxSourceMap({
+      metroMap,
+      mpxMap,
+      generatedSource: 'app.js',
+      onWarn: (message) => warnings.push(message)
+    })
+
+    expect(warnings).toEqual([])
+    const tracedMapping = await generatedMappingForLine(composedMap, 1)
+    expect(tracedMapping.source).toBe(mpxSource)
+    expect(tracedMapping.originalLine).toBe(8)
+    expect(tracedMapping.originalColumn).toBe(2)
+
+    const fallbackMapping = await generatedMappingForLine(composedMap, 2)
+    expect(fallbackMapping.source).toBe(appSource)
+    expect(fallbackMapping.originalLine).toBe(1)
+    expect(fallbackMapping.originalColumn).toBe(0)
+    expect(fallbackMapping.name).toBe('bootstrap')
+  })
+
   test('fails when Metro map has no app.js mapping', async () => {
     const metroMap = createMap({
       file: 'main.jsbundle',
@@ -233,6 +292,40 @@ describe('compose-mpx-sourcemap', () => {
     ])).rejects.toMatchObject({
       exitCode: 1
     })
+  })
+
+  test('CLI can keep Metro sourcemap and exit zero when compose fails', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mpx-rn-cli-fallback-'))
+    const scriptPath = path.resolve(__dirname, '../lib/rn/compose-mpx-sourcemap.js')
+    const metroMapPath = path.join(tempDir, 'index.android.bundle.map')
+    const metroMap = createMap({
+      file: 'index.android.bundle',
+      mappings: [
+        {
+          generated: { line: 1, column: 0 },
+          original: { line: 1, column: 0 },
+          source: 'app.js'
+        }
+      ],
+      sourcesContent: {
+        'app.js': 'require("./app")'
+      }
+    })
+    writeMapFile(metroMapPath, metroMap)
+
+    const result = await execa.node(scriptPath, [
+      '--metro-map',
+      metroMapPath,
+      '--mpx-map',
+      path.join(tempDir, 'missing-app.js.map'),
+      '--output',
+      metroMapPath,
+      '--allow-failure'
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toMatch(/keep Metro sourcemap/)
+    expect(JSON.parse(fs.readFileSync(metroMapPath, 'utf8')).sources).toEqual(metroMap.sources)
   })
 })
 
@@ -463,9 +556,17 @@ describe('RN project sourcemap generation config', () => {
     expect(pkg.devDependencies).toHaveProperty('source-map', '^0.7.6')
     expect(pkg.devDependencies).not.toHaveProperty('@jridgewell/remapping')
     expect(pkg.scripts['bundle:ios']).toContain('--sourcemap-output ./ios/main.jsbundle.map')
-    expect(pkg.scripts['bundle:ios']).toContain('node ./scripts/compose-mpx-sourcemap.js')
+    expect(pkg.scripts['bundle:ios']).toContain('npm run compose-sourcemap:ios')
+    expect(pkg.scripts['bundle:ios']).not.toContain('node ./scripts/compose-mpx-sourcemap.js')
     expect(pkg.scripts['bundle:android']).toContain('--sourcemap-output android/app/src/main/assets/index.android.bundle.map')
-    expect(pkg.scripts['bundle:android']).toContain('node ./scripts/compose-mpx-sourcemap.js')
+    expect(pkg.scripts['bundle:android']).toContain('npm run compose-sourcemap:android')
+    expect(pkg.scripts['bundle:android']).not.toContain('node ./scripts/compose-mpx-sourcemap.js')
+    expect(pkg.scripts['compose-sourcemap:ios']).toContain('node ./scripts/compose-mpx-sourcemap.js')
+    expect(pkg.scripts['compose-sourcemap:ios']).toContain('--metro-map ./ios/main.jsbundle.map')
+    expect(pkg.scripts['compose-sourcemap:ios']).toContain('--allow-failure')
+    expect(pkg.scripts['compose-sourcemap:android']).toContain('node ./scripts/compose-mpx-sourcemap.js')
+    expect(pkg.scripts['compose-sourcemap:android']).toContain('--metro-map android/app/src/main/assets/index.android.bundle.map')
+    expect(pkg.scripts['compose-sourcemap:android']).toContain('--allow-failure')
   })
 
   test('copies compose script into generated RN project', () => {

--- a/packages/mpx-cli/lib/createRn.js
+++ b/packages/mpx-cli/lib/createRn.js
@@ -32,8 +32,10 @@ const RN_DEV_DEP = {
 }
 
 const RN_SCRIPTS = {
-  'bundle:ios': 'react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ./ios/main.jsbundle --assets-dest ./ios --sourcemap-output ./ios/main.jsbundle.map && node ./scripts/compose-mpx-sourcemap.js --metro-map ./ios/main.jsbundle.map --mpx-map ./app.js.map --output ./ios/main.jsbundle.map',
-  'bundle:android': 'react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/ --sourcemap-output android/app/src/main/assets/index.android.bundle.map && node ./scripts/compose-mpx-sourcemap.js --metro-map android/app/src/main/assets/index.android.bundle.map --mpx-map ./app.js.map --output android/app/src/main/assets/index.android.bundle.map'
+  'bundle:ios': 'react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ./ios/main.jsbundle --assets-dest ./ios --sourcemap-output ./ios/main.jsbundle.map && npm run compose-sourcemap:ios',
+  'bundle:android': 'react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/ --sourcemap-output android/app/src/main/assets/index.android.bundle.map && npm run compose-sourcemap:android',
+  'compose-sourcemap:ios': 'node ./scripts/compose-mpx-sourcemap.js --metro-map ./ios/main.jsbundle.map --mpx-map ./app.js.map --output ./ios/main.jsbundle.map --allow-failure',
+  'compose-sourcemap:android': 'node ./scripts/compose-mpx-sourcemap.js --metro-map android/app/src/main/assets/index.android.bundle.map --mpx-map ./app.js.map --output android/app/src/main/assets/index.android.bundle.map --allow-failure'
 }
 
 const RN_SOURCEMAP_SCRIPTS = [

--- a/packages/mpx-cli/lib/createRn.js
+++ b/packages/mpx-cli/lib/createRn.js
@@ -36,7 +36,28 @@ const RN_SCRIPTS = {
   'bundle:android': 'react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/ --sourcemap-output android/app/src/main/assets/index.android.bundle.map && node ./scripts/compose-mpx-sourcemap.js --metro-map android/app/src/main/assets/index.android.bundle.map --mpx-map ./app.js.map --output android/app/src/main/assets/index.android.bundle.map'
 }
 
-const RN_SOURCEMAP_SCRIPT = path.resolve(__dirname, 'rn/compose-mpx-sourcemap.js')
+const RN_SOURCEMAP_SCRIPTS = [
+  'compose-mpx-sourcemap.js',
+  'metro-mpx-sourcemap-middleware.js'
+].map((file) => path.resolve(__dirname, 'rn', file))
+
+const RN_METRO_CONFIG = `const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+const {enhanceMiddleware} = require('./scripts/metro-mpx-sourcemap-middleware');
+
+/**
+ * Metro configuration
+ * https://reactnative.dev/docs/metro
+ *
+ * @type {import('@react-native/metro-config').MetroConfig}
+ */
+const config = {
+  server: {
+    enhanceMiddleware
+  }
+};
+
+module.exports = mergeConfig(getDefaultConfig(__dirname), config);
+`
 
 function updateJsonFile (filePath, updater) {
   const config = require(filePath)
@@ -66,9 +87,15 @@ function applyRnPackageConfig (pkg) {
 }
 
 function copyRnSourcemapScript (rnProjectPath) {
-  const dest = path.resolve(rnProjectPath, 'scripts/compose-mpx-sourcemap.js')
-  fs.mkdirSync(path.dirname(dest), { recursive: true })
-  fs.copyFileSync(RN_SOURCEMAP_SCRIPT, dest)
+  const scriptDir = path.resolve(rnProjectPath, 'scripts')
+  fs.mkdirSync(scriptDir, { recursive: true })
+  RN_SOURCEMAP_SCRIPTS.forEach((src) => {
+    fs.copyFileSync(src, path.resolve(scriptDir, path.basename(src)))
+  })
+}
+
+function writeRnMetroConfig (rnProjectPath) {
+  fs.writeFileSync(path.resolve(rnProjectPath, 'metro.config.js'), RN_METRO_CONFIG)
 }
 
 async function createRnProject (targetDir, options) {
@@ -113,6 +140,7 @@ async function createRnProject (targetDir, options) {
   })
 
   copyRnSourcemapScript(rnProjectPath)
+  writeRnMetroConfig(rnProjectPath)
 
   await pm.install()
 }
@@ -120,3 +148,4 @@ async function createRnProject (targetDir, options) {
 module.exports.createRnProject = createRnProject
 module.exports.applyRnPackageConfig = applyRnPackageConfig
 module.exports.copyRnSourcemapScript = copyRnSourcemapScript
+module.exports.writeRnMetroConfig = writeRnMetroConfig

--- a/packages/mpx-cli/lib/createRn.js
+++ b/packages/mpx-cli/lib/createRn.js
@@ -27,10 +27,16 @@ const RN_DEP = {
   'react-native-vision-camera': '^5.0.10'
 }
 
-const RN_SCRIPTS = {
-  'bundle:ios': 'react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ./ios/main.jsbundle --assets-dest ./ios',
-  'bundle:android': 'react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/'
+const RN_DEV_DEP = {
+  'source-map': '^0.7.6'
 }
+
+const RN_SCRIPTS = {
+  'bundle:ios': 'react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ./ios/main.jsbundle --assets-dest ./ios --sourcemap-output ./ios/main.jsbundle.map && node ./scripts/compose-mpx-sourcemap.js --metro-map ./ios/main.jsbundle.map --mpx-map ./app.js.map --output ./ios/main.jsbundle.map',
+  'bundle:android': 'react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/ --sourcemap-output android/app/src/main/assets/index.android.bundle.map && node ./scripts/compose-mpx-sourcemap.js --metro-map android/app/src/main/assets/index.android.bundle.map --mpx-map ./app.js.map --output android/app/src/main/assets/index.android.bundle.map'
+}
+
+const RN_SOURCEMAP_SCRIPT = path.resolve(__dirname, 'rn/compose-mpx-sourcemap.js')
 
 function updateJsonFile (filePath, updater) {
   const config = require(filePath)
@@ -48,6 +54,21 @@ function addArrayItem (arr, item) {
   if (!arr.includes(item)) {
     arr.push(item)
   }
+}
+
+function applyRnPackageConfig (pkg) {
+  if (!pkg.dependencies) pkg.dependencies = {}
+  if (!pkg.devDependencies) pkg.devDependencies = {}
+  if (!pkg.scripts) pkg.scripts = {}
+  Object.assign(pkg.dependencies, RN_DEP)
+  Object.assign(pkg.devDependencies, RN_DEV_DEP)
+  Object.assign(pkg.scripts, RN_SCRIPTS)
+}
+
+function copyRnSourcemapScript (rnProjectPath) {
+  const dest = path.resolve(rnProjectPath, 'scripts/compose-mpx-sourcemap.js')
+  fs.mkdirSync(path.dirname(dest), { recursive: true })
+  fs.copyFileSync(RN_SOURCEMAP_SCRIPT, dest)
 }
 
 async function createRnProject (targetDir, options) {
@@ -81,10 +102,7 @@ async function createRnProject (targetDir, options) {
   )
 
   const pkgPath = path.resolve(targetDir, 'ReactNativeProject', 'package.json')
-  updateJsonFile(pkgPath, pkg => {
-    Object.assign(pkg.dependencies, RN_DEP)
-    Object.assign(pkg.scripts, RN_SCRIPTS)
-  })
+  updateJsonFile(pkgPath, applyRnPackageConfig)
 
   const babelConfigPath = path.resolve(targetDir, 'ReactNativeProject', 'babel.config.js')
   updateJsModule(babelConfigPath, config => {
@@ -94,7 +112,11 @@ async function createRnProject (targetDir, options) {
     addArrayItem(config.plugins, 'react-native-reanimated/plugin')
   })
 
+  copyRnSourcemapScript(rnProjectPath)
+
   await pm.install()
 }
 
 module.exports.createRnProject = createRnProject
+module.exports.applyRnPackageConfig = applyRnPackageConfig
+module.exports.copyRnSourcemapScript = copyRnSourcemapScript

--- a/packages/mpx-cli/lib/rn/compose-mpx-sourcemap.js
+++ b/packages/mpx-cli/lib/rn/compose-mpx-sourcemap.js
@@ -72,7 +72,6 @@ async function composeMpxSourceMap (options) {
   const metroMap = options.metroMap
   const mpxMap = options.mpxMap
   const generatedSource = options.generatedSource || 'app.js'
-  const onWarn = options.onWarn || function () {}
   const sourceContentBySource = new Map()
   const generator = new SourceMapGenerator({ file: metroMap.file })
   const metroConsumer = await createConsumer(metroMap)
@@ -92,7 +91,6 @@ async function composeMpxSourceMap (options) {
       if (mapping.originalLine == null || mapping.originalColumn == null) {
         addMapping(generator, mapping)
         recordSourceContent(sourceContentBySource, metroConsumer, mapping.source)
-        onWarn(`Cannot trace ${generatedSource} mapping without original position at generated ${mapping.generatedLine}:${mapping.generatedColumn}`)
         return
       }
 
@@ -104,7 +102,6 @@ async function composeMpxSourceMap (options) {
       if (original.source == null || original.line == null || original.column == null) {
         addMapping(generator, mapping)
         recordSourceContent(sourceContentBySource, metroConsumer, mapping.source)
-        onWarn(`Cannot trace ${generatedSource} mapping ${mapping.originalLine}:${mapping.originalColumn} through Mpx sourcemap`)
         return
       }
 
@@ -194,6 +191,8 @@ function parseArgs (argv) {
     } else if (arg === '--generated-source') {
       options.generatedSource = value
       i++
+    } else if (arg === '--allow-failure') {
+      options.allowFailure = true
     } else if (arg === '--help' || arg === '-h') {
       options.help = true
     } else {
@@ -202,7 +201,7 @@ function parseArgs (argv) {
   }
 
   if (options.help || !options.metroMapPath || !options.mpxMapPath) {
-    throw new Error('Usage: node ./scripts/compose-mpx-sourcemap.js --metro-map <metro.map> --mpx-map <app.js.map> [--output <output.map>] [--generated-source app.js]')
+    throw new Error('Usage: node ./scripts/compose-mpx-sourcemap.js --metro-map <metro.map> --mpx-map <app.js.map> [--output <output.map>] [--generated-source app.js] [--allow-failure]')
   }
 
   if (!options.outputPath) {
@@ -214,13 +213,21 @@ function parseArgs (argv) {
 
 async function runCli (argv) {
   const options = parseArgs(argv)
-  await composeMpxSourceMapFiles({
-    metroMapPath: options.metroMapPath,
-    mpxMapPath: options.mpxMapPath,
-    outputPath: options.outputPath,
-    generatedSource: options.generatedSource,
-    onWarn: (message) => console.warn(`[mpx sourcemap] ${message}`)
-  })
+  try {
+    await composeMpxSourceMapFiles({
+      metroMapPath: options.metroMapPath,
+      mpxMapPath: options.mpxMapPath,
+      outputPath: options.outputPath,
+      generatedSource: options.generatedSource,
+      onWarn: (message) => console.warn(`[mpx sourcemap] ${message}`)
+    })
+  } catch (error) {
+    if (!options.allowFailure) {
+      throw error
+    }
+    console.warn(`[mpx sourcemap] ${error.message}`)
+    console.warn('[mpx sourcemap] Compose failed; keep Metro sourcemap')
+  }
 }
 
 if (require.main === module) {

--- a/packages/mpx-cli/lib/rn/compose-mpx-sourcemap.js
+++ b/packages/mpx-cli/lib/rn/compose-mpx-sourcemap.js
@@ -233,6 +233,8 @@ if (require.main === module) {
 module.exports = {
   composeMpxSourceMap,
   composeMpxSourceMapFiles,
+  isGeneratedSource,
+  normalizeSourcePath,
   parseArgs,
   runCli
 }

--- a/packages/mpx-cli/lib/rn/compose-mpx-sourcemap.js
+++ b/packages/mpx-cli/lib/rn/compose-mpx-sourcemap.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+const { SourceMapConsumer, SourceMapGenerator } = require('source-map')
+
+function normalizeSourcePath (source) {
+  return String(source || '')
+    .replace(/\\/g, '/')
+    .split('?')[0]
+    .split('#')[0]
+}
+
+function isGeneratedSource (source, generatedSource) {
+  const normalizedSource = normalizeSourcePath(source)
+  const normalizedGeneratedSource = normalizeSourcePath(generatedSource)
+  return normalizedSource === normalizedGeneratedSource ||
+    normalizedSource.endsWith('/' + normalizedGeneratedSource)
+}
+
+async function createConsumer (map) {
+  return new SourceMapConsumer(map)
+}
+
+function destroyConsumer (consumer) {
+  if (consumer && consumer.destroy) {
+    consumer.destroy()
+  }
+}
+
+function addMapping (generator, mapping) {
+  const nextMapping = {
+    generated: {
+      line: mapping.generatedLine,
+      column: mapping.generatedColumn
+    }
+  }
+
+  if (
+    mapping.source != null &&
+    mapping.originalLine != null &&
+    mapping.originalColumn != null
+  ) {
+    nextMapping.original = {
+      line: mapping.originalLine,
+      column: mapping.originalColumn
+    }
+    nextMapping.source = mapping.source
+    if (mapping.name != null) {
+      nextMapping.name = mapping.name
+    }
+  }
+
+  generator.addMapping(nextMapping)
+}
+
+function recordSourceContent (sourceContentBySource, consumer, source) {
+  if (!source || sourceContentBySource.has(source)) return
+  const content = consumer.sourceContentFor(source, true)
+  if (content != null) {
+    sourceContentBySource.set(source, content)
+  }
+}
+
+function setSourceContents (generator, sourceContentBySource) {
+  sourceContentBySource.forEach((content, source) => {
+    generator.setSourceContent(source, content)
+  })
+}
+
+async function composeMpxSourceMap (options) {
+  const metroMap = options.metroMap
+  const mpxMap = options.mpxMap
+  const generatedSource = options.generatedSource || 'app.js'
+  const onWarn = options.onWarn || function () {}
+  const sourceContentBySource = new Map()
+  const generator = new SourceMapGenerator({ file: metroMap.file })
+  const metroConsumer = await createConsumer(metroMap)
+  const mpxConsumer = await createConsumer(mpxMap)
+  let matchedAppMappings = 0
+  let tracedMpxMappings = 0
+
+  try {
+    metroConsumer.eachMapping((mapping) => {
+      if (!isGeneratedSource(mapping.source, generatedSource)) {
+        addMapping(generator, mapping)
+        recordSourceContent(sourceContentBySource, metroConsumer, mapping.source)
+        return
+      }
+
+      matchedAppMappings++
+      if (mapping.originalLine == null || mapping.originalColumn == null) {
+        addMapping(generator, mapping)
+        recordSourceContent(sourceContentBySource, metroConsumer, mapping.source)
+        onWarn(`Cannot trace ${generatedSource} mapping without original position at generated ${mapping.generatedLine}:${mapping.generatedColumn}`)
+        return
+      }
+
+      const original = mpxConsumer.originalPositionFor({
+        line: mapping.originalLine,
+        column: mapping.originalColumn
+      })
+
+      if (original.source == null || original.line == null || original.column == null) {
+        addMapping(generator, mapping)
+        recordSourceContent(sourceContentBySource, metroConsumer, mapping.source)
+        onWarn(`Cannot trace ${generatedSource} mapping ${mapping.originalLine}:${mapping.originalColumn} through Mpx sourcemap`)
+        return
+      }
+
+      tracedMpxMappings++
+      addMapping(generator, {
+        generatedLine: mapping.generatedLine,
+        generatedColumn: mapping.generatedColumn,
+        originalLine: original.line,
+        originalColumn: original.column,
+        source: original.source,
+        name: original.name || mapping.name
+      })
+      recordSourceContent(sourceContentBySource, mpxConsumer, original.source)
+    })
+
+    if (matchedAppMappings === 0) {
+      throw new Error(`No Metro mappings matched ${generatedSource}; sourcemap was not composed`)
+    }
+    if (tracedMpxMappings === 0) {
+      throw new Error(`No ${generatedSource} mappings could be traced through Mpx sourcemap`)
+    }
+
+    setSourceContents(generator, sourceContentBySource)
+    return generator.toJSON()
+  } finally {
+    destroyConsumer(metroConsumer)
+    destroyConsumer(mpxConsumer)
+  }
+}
+
+function readJsonMap (filePath, label) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`${label} sourcemap not found: ${filePath}`)
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch (error) {
+    throw new Error(`Failed to parse ${label} sourcemap: ${filePath}\n${error.message}`)
+  }
+}
+
+async function composeMpxSourceMapFiles (options) {
+  const metroMapPath = options.metroMapPath
+  const mpxMapPath = options.mpxMapPath
+  const outputPath = options.outputPath || metroMapPath
+  const metroMap = readJsonMap(metroMapPath, 'Metro')
+  const mpxMap = readJsonMap(mpxMapPath, 'Mpx')
+  const composedMap = await composeMpxSourceMap({
+    metroMap,
+    mpxMap,
+    generatedSource: options.generatedSource,
+    onWarn: options.onWarn
+  })
+  const tempPath = `${outputPath}.${process.pid}.${Date.now()}.tmp`
+
+  try {
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+    fs.writeFileSync(tempPath, JSON.stringify(composedMap), 'utf8')
+    fs.renameSync(tempPath, outputPath)
+  } catch (error) {
+    if (fs.existsSync(tempPath)) {
+      fs.unlinkSync(tempPath)
+    }
+    throw error
+  }
+
+  return composedMap
+}
+
+function parseArgs (argv) {
+  const options = {
+    generatedSource: 'app.js'
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    const value = argv[i + 1]
+    if (arg === '--metro-map') {
+      options.metroMapPath = value
+      i++
+    } else if (arg === '--mpx-map') {
+      options.mpxMapPath = value
+      i++
+    } else if (arg === '--output') {
+      options.outputPath = value
+      i++
+    } else if (arg === '--generated-source') {
+      options.generatedSource = value
+      i++
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (options.help || !options.metroMapPath || !options.mpxMapPath) {
+    throw new Error('Usage: node ./scripts/compose-mpx-sourcemap.js --metro-map <metro.map> --mpx-map <app.js.map> [--output <output.map>] [--generated-source app.js]')
+  }
+
+  if (!options.outputPath) {
+    options.outputPath = options.metroMapPath
+  }
+
+  return options
+}
+
+async function runCli (argv) {
+  const options = parseArgs(argv)
+  await composeMpxSourceMapFiles({
+    metroMapPath: options.metroMapPath,
+    mpxMapPath: options.mpxMapPath,
+    outputPath: options.outputPath,
+    generatedSource: options.generatedSource,
+    onWarn: (message) => console.warn(`[mpx sourcemap] ${message}`)
+  })
+}
+
+if (require.main === module) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    console.error(`[mpx sourcemap] ${error.message}`)
+    process.exitCode = 1
+  })
+}
+
+module.exports = {
+  composeMpxSourceMap,
+  composeMpxSourceMapFiles,
+  parseArgs,
+  runCli
+}

--- a/packages/mpx-cli/lib/rn/compose-mpx-sourcemap.js
+++ b/packages/mpx-cli/lib/rn/compose-mpx-sourcemap.js
@@ -152,8 +152,7 @@ async function composeMpxSourceMapFiles (options) {
   const composedMap = await composeMpxSourceMap({
     metroMap,
     mpxMap,
-    generatedSource: options.generatedSource,
-    onWarn: options.onWarn
+    generatedSource: options.generatedSource
   })
   const tempPath = `${outputPath}.${process.pid}.${Date.now()}.tmp`
 
@@ -218,8 +217,7 @@ async function runCli (argv) {
       metroMapPath: options.metroMapPath,
       mpxMapPath: options.mpxMapPath,
       outputPath: options.outputPath,
-      generatedSource: options.generatedSource,
-      onWarn: (message) => console.warn(`[mpx sourcemap] ${message}`)
+      generatedSource: options.generatedSource
     })
   } catch (error) {
     if (!options.allowFailure) {

--- a/packages/mpx-cli/lib/rn/metro-mpx-sourcemap-middleware.js
+++ b/packages/mpx-cli/lib/rn/metro-mpx-sourcemap-middleware.js
@@ -1,0 +1,189 @@
+const fs = require('fs')
+const path = require('path')
+const { Buffer } = require('buffer')
+const { SourceMapConsumer } = require('source-map')
+const {
+  composeMpxSourceMap,
+  isGeneratedSource
+} = require('./compose-mpx-sourcemap')
+
+const DEFAULT_MPX_MAP_PATH = path.resolve(__dirname, '../app.js.map')
+const warnedMessages = new Set()
+
+function defaultWarn (message) {
+  console.warn(`[mpx sourcemap] ${message}`)
+}
+
+function warnOnce (warn, message) {
+  if (warnedMessages.has(message)) return
+  warnedMessages.add(message)
+  warn(message)
+}
+
+function parsePathname (req) {
+  try {
+    return new URL(req.url || '', 'http://localhost').pathname || ''
+  } catch (error) {
+    return ''
+  }
+}
+
+function shouldHandleMapRequest (req) {
+  return req.method === 'GET' && parsePathname(req).endsWith('.map')
+}
+
+function shouldHandleSymbolicateRequest (req) {
+  return req.method === 'POST' && parsePathname(req) === '/symbolicate'
+}
+
+function readMpxMap (mpxMapPath) {
+  if (!fs.existsSync(mpxMapPath)) {
+    throw new Error(`Mpx sourcemap not found: ${mpxMapPath}`)
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(mpxMapPath, 'utf8'))
+  } catch (error) {
+    throw new Error(`Failed to parse Mpx sourcemap: ${mpxMapPath}\n${error.message}`)
+  }
+}
+
+function toBuffer (chunk, encoding) {
+  if (Buffer.isBuffer(chunk)) return chunk
+  return Buffer.from(String(chunk), typeof encoding === 'string' ? encoding : undefined)
+}
+
+function setJsonHeaders (res, body) {
+  if (res.headersSent) return
+  if (res.setHeader) {
+    res.setHeader('Content-Type', 'application/json')
+    res.setHeader('Content-Length', Buffer.byteLength(body))
+  }
+}
+
+function interceptResponseBody (res, transformBody) {
+  const originalWrite = res.write.bind(res)
+  const originalEnd = res.end.bind(res)
+  const chunks = []
+
+  res.write = function (chunk, encoding, cb) {
+    if (chunk) {
+      chunks.push(toBuffer(chunk, encoding))
+    }
+    if (typeof cb === 'function') cb()
+    return true
+  }
+
+  res.end = function (chunk, encoding, cb) {
+    if (typeof encoding === 'function') {
+      cb = encoding
+      encoding = undefined
+    }
+    if (chunk) {
+      chunks.push(toBuffer(chunk, encoding))
+    }
+
+    const originalBody = Buffer.concat(chunks).toString()
+    Promise.resolve(transformBody(originalBody))
+      .then((body) => {
+        setJsonHeaders(res, body)
+        originalEnd(body, 'utf8', cb)
+      })
+      .catch(() => {
+        originalWrite(Buffer.concat(chunks))
+        originalEnd(null, undefined, cb)
+      })
+  }
+}
+
+async function traceFrameToMpxSource (frame, mpxMap, generatedSource) {
+  if (!frame || !isGeneratedSource(frame.file, generatedSource)) return frame
+  if (typeof frame.lineNumber !== 'number') return frame
+
+  const consumer = await new SourceMapConsumer(mpxMap)
+  try {
+    const original = consumer.originalPositionFor({
+      line: frame.lineNumber,
+      column: typeof frame.column === 'number' ? frame.column : 0
+    })
+
+    if (original.source == null || original.line == null || original.column == null) {
+      return frame
+    }
+
+    return {
+      ...frame,
+      file: original.source,
+      lineNumber: original.line,
+      column: original.column,
+      methodName: original.name || frame.methodName
+    }
+  } finally {
+    if (consumer.destroy) {
+      consumer.destroy()
+    }
+  }
+}
+
+async function composeMapResponse (body, mpxMap, warn, generatedSource) {
+  const metroMap = JSON.parse(body)
+  const composedMap = await composeMpxSourceMap({
+    metroMap,
+    mpxMap,
+    generatedSource,
+    onWarn: (message) => warnOnce(warn, message)
+  })
+  return JSON.stringify(composedMap)
+}
+
+async function composeSymbolicateResponse (body, mpxMap, generatedSource) {
+  const response = JSON.parse(body)
+  if (!response || !Array.isArray(response.symbolicatedStack)) {
+    throw new Error('Metro symbolicate response does not contain symbolicatedStack')
+  }
+
+  response.symbolicatedStack = await Promise.all(
+    response.symbolicatedStack.map((frame) => traceFrameToMpxSource(frame, mpxMap, generatedSource))
+  )
+  return JSON.stringify(response)
+}
+
+function createMpxSourcemapMiddleware (options = {}) {
+  const mpxMapPath = options.mpxMapPath || DEFAULT_MPX_MAP_PATH
+  const generatedSource = options.generatedSource || 'app.js'
+  const warn = options.warn || defaultWarn
+
+  return function enhanceMiddleware (middleware) {
+    return function mpxSourcemapMiddleware (req, res, next) {
+      const isMapRequest = shouldHandleMapRequest(req)
+      const isSymbolicateRequest = shouldHandleSymbolicateRequest(req)
+
+      if (!isMapRequest && !isSymbolicateRequest) {
+        return middleware(req, res, next)
+      }
+
+      interceptResponseBody(res, async (body) => {
+        try {
+          const mpxMap = readMpxMap(mpxMapPath)
+          if (isMapRequest) {
+            return await composeMapResponse(body, mpxMap, warn, generatedSource)
+          }
+          return await composeSymbolicateResponse(body, mpxMap, generatedSource)
+        } catch (error) {
+          warnOnce(warn, error.message)
+          return body
+        }
+      })
+
+      return middleware(req, res, next)
+    }
+  }
+}
+
+const enhanceMiddleware = createMpxSourcemapMiddleware()
+
+module.exports = {
+  createMpxSourcemapMiddleware,
+  enhanceMiddleware,
+  traceFrameToMpxSource
+}

--- a/packages/mpx-cli/lib/rn/metro-mpx-sourcemap-middleware.js
+++ b/packages/mpx-cli/lib/rn/metro-mpx-sourcemap-middleware.js
@@ -125,13 +125,12 @@ async function traceFrameToMpxSource (frame, mpxMap, generatedSource) {
   }
 }
 
-async function composeMapResponse (body, mpxMap, warn, generatedSource) {
+async function composeMapResponse (body, mpxMap, generatedSource) {
   const metroMap = JSON.parse(body)
   const composedMap = await composeMpxSourceMap({
     metroMap,
     mpxMap,
-    generatedSource,
-    onWarn: (message) => warnOnce(warn, message)
+    generatedSource
   })
   return JSON.stringify(composedMap)
 }
@@ -166,7 +165,7 @@ function createMpxSourcemapMiddleware (options = {}) {
         try {
           const mpxMap = readMpxMap(mpxMapPath)
           if (isMapRequest) {
-            return await composeMapResponse(body, mpxMap, warn, generatedSource)
+            return await composeMapResponse(body, mpxMap, generatedSource)
           }
           return await composeSymbolicateResponse(body, mpxMap, generatedSource)
         } catch (error) {


### PR DESCRIPTION
## Issue

上游 Issue：https://github.com/didi/mpx/issues/2502

## Background

RN 场景下 Metro 生成的 sourcemap 只能定位到构建后的 `app.js`，无法继续追溯到 Mpx 源文件，导致线上 bundle 和 dev symbolicate 场景里的报错栈不够可读。

## Summary

- 在 `mpx-cli` 中为 React Native 构建添加 sourcemap 合并能力，支持 build 模式将 Metro bundle 坐标反解到 Mpx 源码。
- 新增 RN `enhanceMiddleware` 中间件，支持 dev 模式下动态合并 sourcemap，并将 `/symbolicate` 中的 `app.js` 栈帧改写到 Mpx 源码位置。
- 配套更新 RN 项目生成逻辑、bundle 脚本、sourcemap 合并脚本和相关单测。
- 增加降级处理：合并失败时保留 Metro 原始 sourcemap，避免阻断 RN bundle 流程。

## Test

- 新增单测：rn-sourcemap.spec.js
- Demo 验证生成模式和 Dev 模式功能正常，Dev 断点截图如下（可以看到 Mpx 业务源码以及正常断点）：

<img width="1566" height="893" alt="SCR-20260611-qrmh" src="https://github.com/user-attachments/assets/729870d5-b47a-4fb4-9f6d-d55d45a5a619" />

