### PR TITLE
feat: 允许 preset 对内置 prompts 做修改 & 最新版pnpm支持

### DIFF
--- a/packages/mpx-cli/lib/create.js
+++ b/packages/mpx-cli/lib/create.js
@@ -13,6 +13,8 @@ const {
 } = require('@vue/cli-shared-utils')
 const { loadOptions } = require('@vue/cli/lib/options')
 const Creator = require('@vue/cli/lib/Creator')
+const ProjectPackageManager = require('@vue/cli/lib/util/ProjectPackageManager')
+const { executeCommand } = require('@vue/cli/lib/util/executeCommand')
 const loadRemotePreset = require('@vue/cli/lib/util/loadRemotePreset')
 const loadLocalPreset = require('@vue/cli/lib/util/loadLocalPreset')
 const { getPromptModules } = require('@vue/cli/lib/util/createTools')
@@ -21,6 +23,45 @@ const merge = require('lodash.merge')
 const prompts = require('./prompts')
 const builtInPreset = require('./preset')
 const { createRnProject } = require('./createRn')
+const MpxCliPromptsKey = 'mpxCliPrompts'
+const PnpmShamefullyHoistConfigRegExp = /^shamefully-(hoist|flatten)=.*$/gm
+
+// Vue CLI 对 pnpm 会默认追加 shamefully-hoist 相关安装参数，容易改变依赖解析结构。
+// 这里单独接管 pnpm 命令，保留 registry 环境变量处理，同时避免 hoist 配置影响新项目。
+function patchPnpmInstallArgs () {
+  if (ProjectPackageManager.__mpxNoShamefullyHoist) {
+    return
+  }
+  const originalRunCommand = ProjectPackageManager.prototype.runCommand
+  ProjectPackageManager.prototype.runCommand = function (command, args) {
+    if (this.bin !== 'pnpm') {
+      return originalRunCommand.call(this, command, args)
+    }
+    const commandArgs = {
+      install: ['install', '--reporter', 'silent'],
+      add: ['install', '--reporter', 'silent'],
+      upgrade: ['update', '--reporter', 'silent'],
+      remove: ['uninstall', '--reporter', 'silent']
+    }
+    const prevNodeEnv = process.env.NODE_ENV
+    delete process.env.NODE_ENV
+    return this.setRegistryEnvs()
+      .then(() => executeCommand(
+        this.bin,
+        [
+          ...commandArgs[command],
+          ...(args || [])
+        ],
+        this.context
+      ))
+      .finally(() => {
+        if (prevNodeEnv) {
+          process.env.NODE_ENV = prevNodeEnv
+        }
+      })
+  }
+  ProjectPackageManager.__mpxNoShamefullyHoist = true
+}
 
 async function resolvePreset (args = {}) {
   const { p, preset, c, clone } = args
@@ -48,24 +89,163 @@ async function resolvePreset (args = {}) {
   return res
 }
 
-async function resolvePrompts () {
-  return inquirer.prompt(prompts).then((answers) => answers)
+// preset 需要以 JSON 形式表达交互问题的展示条件，不能直接传函数。
+// 这里支持 all/any/not 组合条件，供 mpxCliPrompts.modify/add 中的 when 使用。
+function matchPromptCondition (condition, answers) {
+  if (!condition || typeof condition !== 'object' || Array.isArray(condition)) {
+    return !!condition
+  }
+  if (condition.all) {
+    return condition.all.every((item) => matchPromptCondition(item, answers))
+  }
+  if (condition.any) {
+    return condition.any.some((item) => matchPromptCondition(item, answers))
+  }
+  if (condition.not) {
+    return !matchPromptCondition(condition.not, answers)
+  }
+  return Object.keys(condition).every((key) => {
+    const expected = condition[key]
+    const actual = answers[key]
+    return Array.isArray(expected)
+      ? expected.includes(actual)
+      : actual === expected
+  })
 }
 
-async function mergePreset (preset, options) {
+function createWhenMatcher (when) {
+  if (!when || typeof when !== 'object' || Array.isArray(when)) {
+    return when
+  }
+  return (answers) => matchPromptCondition(when, answers)
+}
+
+function normalizePrompt (prompt) {
+  return {
+    ...prompt,
+    when: createWhenMatcher(prompt.when)
+  }
+}
+
+// 允许 preset 通过 mpxCliPrompts 对内置问题做增删改，便于业务模板控制问答流程。
+function resolvePromptList (promptList, promptOptions = {}) {
+  const list = promptList.map((prompt) => ({ ...prompt }))
+  const { remove = [], modify = {}, add = [] } = promptOptions || {}
+  remove.forEach((name) => {
+    const index = list.findIndex((prompt) => prompt.name === name)
+    if (index > -1) {
+      list.splice(index, 1)
+    }
+  })
+  Object.keys(modify).forEach((name) => {
+    const index = list.findIndex((prompt) => prompt.name === name)
+    if (index > -1) {
+      list[index] = normalizePrompt({
+        ...list[index],
+        ...modify[name]
+      })
+    }
+  })
+  add.forEach((prompt) => {
+    const normalizedPrompt = normalizePrompt(prompt)
+    let insertIndex = -1
+    if (prompt.before) {
+      insertIndex = list.findIndex((item) => item.name === prompt.before)
+    } else if (prompt.after) {
+      const afterIndex = list.findIndex((item) => item.name === prompt.after)
+      insertIndex = afterIndex > -1 ? afterIndex + 1 : -1
+    }
+    delete normalizedPrompt.before
+    delete normalizedPrompt.after
+    if (insertIndex > -1) {
+      list.splice(insertIndex, 0, normalizedPrompt)
+    } else {
+      list.push(normalizedPrompt)
+    }
+  })
+  return list
+}
+
+function escapeRegExp (str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// pnpm 的 overrides/allowBuilds 放在 pnpm-workspace.yaml 更稳定，避免写在 package.json 后
+// 被不同 pnpm 版本或 workspace 场景忽略。
+function ensureYamlMapEntries (content, mapName, entries) {
+  if (content && !content.endsWith('\n')) {
+    content += '\n'
+  }
+  if (!content.includes(`${mapName}:`)) {
+    content += `${content ? '\n' : ''}${mapName}:\n`
+  }
+  Object.keys(entries).forEach((key) => {
+    const value = entries[key]
+    const entryRegExp = new RegExp(`^(\\s{2}${escapeRegExp(key)}:\\s*).*$`, 'm')
+    if (entryRegExp.test(content)) {
+      content = content.replace(entryRegExp, `$1${value}`)
+    } else {
+      content = content.replace(`${mapName}:\n`, `${mapName}:\n  ${key}: ${value}\n`)
+    }
+  })
+  return content
+}
+
+function ensurePnpmWorkspaceSettings (targetDir) {
+  const workspacePath = path.resolve(targetDir, 'pnpm-workspace.yaml')
+  let content = fs.existsSync(workspacePath) ? fs.readFileSync(workspacePath, 'utf-8') : ''
+  content = ensureYamlMapEntries(content, 'overrides', {
+    "'@achrinza/node-ipc'": "'npm:node-ipc-compat@1.0.0'"
+  })
+  content = ensureYamlMapEntries(content, 'allowBuilds', {
+    'core-js-pure': true,
+    'vue-demi': true
+  })
+  fs.writeFileSync(workspacePath, content)
+}
+
+// pnpm 安装时仍需要继承 create 命令传入的 registry，否则生成项目可能访问默认源。
+function ensureNpmrcConfig (targetDir, config) {
+  const npmrcPath = path.resolve(targetDir, '.npmrc')
+  let content = fs.existsSync(npmrcPath) ? fs.readFileSync(npmrcPath, 'utf-8') : ''
+  if (content && !content.endsWith('\n')) {
+    content += '\n'
+  }
+  Object.keys(config).forEach((key) => {
+    if (!content.split('\n').some((line) => line.trim().startsWith(`${key}=`))) {
+      content += `${key}=${config[key]}\n`
+    }
+  })
+  fs.writeFileSync(npmrcPath, content)
+}
+
+// 新项目不再依赖 shamefully-hoist/shamefully-flatten，保留这些配置会掩盖依赖声明问题。
+function removePnpmShamefullyHoistConfig (targetDir) {
+  const npmrcPath = path.resolve(targetDir, '.npmrc')
+  if (!fs.existsSync(npmrcPath)) {
+    return
+  }
+  let content = fs.readFileSync(npmrcPath, 'utf-8')
+  content = content.replace(PnpmShamefullyHoistConfigRegExp, '').replace(/\n{3,}/g, '\n\n').trim()
+  fs.writeFileSync(npmrcPath, content ? `${content}\n` : '')
+}
+
+async function resolvePrompts (promptList) {
+  return inquirer.prompt(promptList).then((answers) => answers)
+}
+
+async function resolveCliPreset (options) {
   if (options.preset) {
-    const remotePreset = await resolvePreset(options)
-    merge(preset, remotePreset)
+    return resolvePreset(options)
   } else if (options.inlinePreset) {
     try {
-      const inlinePreset = JSON.parse(options.inlinePreset)
-      merge(preset, inlinePreset)
+      return JSON.parse(options.inlinePreset)
     } catch (error) {
       error(`CLI inline preset is not valid JSON: ${options.inlinePreset}`)
       exit(1)
     }
   }
-  return preset
+  return {}
 }
 /**
  * 从vue-cli clone 下来，方便处理creator的创建以及生命周期管理
@@ -76,11 +256,16 @@ async function mergePreset (preset, options) {
  */
 async function create (projectName, options, preset = null) {
   // resolve preset
+  let promptList = prompts
   if (!preset) {
+    const cliPreset = await resolveCliPreset(options)
+    // 先用 CLI preset 改造问题列表，再开始问答；这样远程/本地 preset 可以控制交互项。
+    promptList = resolvePromptList(prompts, cliPreset[MpxCliPromptsKey])
     // 默认回答
-    preset = await resolvePrompts()
-    await mergePreset(preset, options)
+    preset = await resolvePrompts(promptList)
+    merge(preset, cliPreset)
   }
+  delete preset[MpxCliPromptsKey]
   // css preprocessor
   preset.cssPreprocessor = 'stylus'
 
@@ -88,7 +273,7 @@ async function create (projectName, options, preset = null) {
   preset.plugins = Object.assign({}, preset.plugins, builtInPreset.plugins)
 
   // 合并问答中的preset
-  prompts.forEach((v) => {
+  promptList.forEach((v) => {
     if (preset[v.name]) {
       merge(preset, v.preset)
     }
@@ -184,8 +369,12 @@ async function create (projectName, options, preset = null) {
     loadOptions().packageManager ||
     (hasYarn() ? 'yarn' : null) ||
     (hasPnpm3OrLater() ? 'pnpm' : 'npm')
+  if (packageManager === 'pnpm') {
+    patchPnpmInstallArgs()
+  }
 
-  // @achrinza/node-ipc与node23不兼容，需要映射到修复包node-ipc-compat@1.0.0
+  // @achrinza/node-ipc 与 Node 23 不兼容，需要映射到修复包 node-ipc-compat@1.0.0。
+  // npm 和 pnpm 的 override 配置位置不同，yarn 暂不处理。
   creator.on('creation', ({ event }) => {
     if (event === 'plugins-install' || event === 'deps-install') {
       try {
@@ -193,10 +382,12 @@ async function create (projectName, options, preset = null) {
         const pkg = fs.readJsonSync(pkgPath)
         // 根据包管理器类型写入对应的 overrides 配置，yarn无需处理
         if (packageManager === 'pnpm') {
-          pkg.pnpm = {
-            overrides: {
-              '@achrinza/node-ipc': 'npm:node-ipc-compat@1.0.0'
-            }
+          removePnpmShamefullyHoistConfig(targetDir)
+          ensurePnpmWorkspaceSettings(targetDir)
+          if (options.registry) {
+            ensureNpmrcConfig(targetDir, {
+              registry: options.registry
+            })
           }
         } else if (packageManager === 'npm') {
           pkg.overrides = {


### PR DESCRIPTION
## 背景

  本次调整主要解决 `mpx create` 在 pnpm 场景下的依赖安装兼容问题，并增强 preset 对交互问答流程的控制能力。

  ## 改动内容

  ### 1. 支持 preset 自定义 CLI 问答流程

  新增 `mpxCliPrompts` 配置，允许 preset 对内置 prompts 做增删改：

  - `remove`：移除指定问题
  - `modify`：修改已有问题配置
  - `add`：新增问题
  - `before` / `after`：控制新增问题插入位置
  - `when`：支持 JSON 化条件表达，包含 `all` / `any` / `not`

  这样远程 preset、本地 preset 和 inline preset 都可以在问答开始前影响交互项。

  ### 2. 优化 pnpm 安装行为

  pnpm 场景下接管 Vue CLI 的安装命令，避免默认追加 `shamefully-hoist` 相关参数，防止依赖结构被隐式改变。

  同时会清理生成项目 `.npmrc` 中的：

  - `shamefully-hoist`
  - `shamefully-flatten`

  ### 3. 修复 overrides 兼容问题

  `@achrinza/node-ipc` 与 Node 23 存在兼容问题，因此将其映射到修复包， 但最新版 pnpm 已不支持package.json中声明overrides：

  ```yaml
  overrides:
    '@achrinza/node-ipc': 'npm:node-ipc-compat@1.0.0'
  ```

  修复后: pnpm 场景下写入 pnpm-workspace.yaml，npm 场景下继续写入 package.json 的 overrides。

  ### 4. 补充 pnpm allowBuilds 配置

  pnpm 项目会写入：
```yaml
  allowBuilds:
    core-js-pure: true
    vue-demi: true
```
  避免 pnpm 构建依赖时被默认拦截, 保持与 npm 一致的效果。

  ### 5. pnpm 场景保留 registry 配置

  如果 create 命令传入了 --registry，会同步写入生成项目的 .npmrc：

  registry=https://registry.npmmirror.com

  确保后续 pnpm install 使用同一个 registry。

  ## 示例

  ### preset 中修改问答项
  ```json
  {
    "mpxCliPrompts": {
      "remove": ["needE2ETest"],
      "modify": {
        "needTs": {
          "default": true
        }
      },
      "add": [
        {
          "name": "enableMock",
          "type": "confirm",
          "message": "是否启用 mock？",
          "default": false,
          "after": "needUnitTest"
        }
      ]
    }
  }
```

  ### 使用条件控制问题展示
```json
  {
    "mpxCliPrompts": {
      "add": [
        {
          "name": "mockType",
          "type": "list",
          "message": "请选择 mock 类型",
          "choices": ["local", "remote"],
          "when": {
            "all": [
              { "enableMock": true },
              { "srcMode": "wx" }
            ]
          }
        }
      ]
    }
  }
```
  ### pnpm 生成后的配置示例

  生成项目中会自动写入或更新 pnpm-workspace.yaml：
```yaml
  overrides:
    '@achrinza/node-ipc': 'npm:node-ipc-compat@1.0.0'
  allowBuilds:
    core-js-pure: true
    vue-demi: true
```
  如果传入 registry，还会写入 .npmrc：
```
  registry=https://registry.npmmirror.com
```
  ## 验证

  - node --check packages/mpx-cli/lib/create.js
  - git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved project creation with enhanced `pnpm` support and quieter package installation.
  - Added more flexible CLI preset handling, including conditional prompts and preset-driven prompt customization.
  - Added support for configuring package registries and workspace overrides during project setup.

- **Bug Fixes**
  - Improved compatibility for projects using `pnpm`, including automatic handling of build and dependency configuration.
  - Removed conflicting legacy `pnpm` settings when applying compatibility adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->