### PR TITLE
fix(cli): 补充 VisionCamera 5 所需的 Nitro 依赖

### DIFF
--- a/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
+++ b/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
@@ -540,8 +540,8 @@ describe('metro-mpx-sourcemap-middleware', () => {
   })
 })
 
-describe('RN project sourcemap generation config', () => {
-  test('adds sourcemap dependencies and bundle scripts to RN package.json', () => {
+describe('RN project generation config', () => {
+  test('adds native and sourcemap dependencies and bundle scripts to RN package.json', () => {
     const pkg = {
       dependencies: {},
       devDependencies: {},
@@ -550,6 +550,8 @@ describe('RN project sourcemap generation config', () => {
 
     applyRnPackageConfig(pkg)
 
+    expect(pkg.dependencies).toHaveProperty('react-native-nitro-image', '^0.15.1')
+    expect(pkg.dependencies).toHaveProperty('react-native-nitro-modules', '^0.36.5')
     expect(pkg.devDependencies).toHaveProperty('source-map', '^0.7.6')
     expect(pkg.devDependencies).not.toHaveProperty('@jridgewell/remapping')
     expect(pkg.scripts['bundle:ios']).toContain('--sourcemap-output ./ios/main.jsbundle.map')

--- a/packages/mpx-cli/lib/createRn.js
+++ b/packages/mpx-cli/lib/createRn.js
@@ -15,6 +15,8 @@ const RN_DEP = {
   'react-native-get-location': '^5.0.0',
   'react-native-haptic-feedback': '^2.3.3',
   'react-native-linear-gradient': '^2.8.3',
+  'react-native-nitro-image': '^0.15.1',
+  'react-native-nitro-modules': '^0.36.5',
   'react-native-reanimated': '3.16.7',
   'react-native-screens': '~4.18.0',
   'react-native-webview': '^13.13.2',


### PR DESCRIPTION
## 问题

使用 MPX CLI 创建支持 React Native 的项目后，在生成工程的 `ReactNativeProject/ios` 目录执行：

```bash
bundle exec pod install
```

CocoaPods 解析 VisionCamera 依赖时失败：

```text
[!] Unable to find a specification for `NitroModules` depended upon by `VisionCamera`
```

原因是生成的 RN 工程安装了 VisionCamera 5，但缺少其必需的 `react-native-nitro-modules` 和 `react-native-nitro-image`。

## 修复

- 为生成的 RN 工程补充两个 Nitro 依赖。
- 增加依赖生成的回归测试。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * React Native projects now include support for Nitro image handling and Nitro modules.

* **Tests**
  * Expanded project generation checks to verify the required Nitro dependencies are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->