### PR TITLE
fix: fix rn cli && support rn project name

### DIFF
--- a/packages/mpx-cli/__tests__/preset.spec.js
+++ b/packages/mpx-cli/__tests__/preset.spec.js
@@ -344,6 +344,7 @@ test('test-rn', async () => {
       appid: 'test',
       description: 'test',
       needRn: true,
+      rnProjectName: 'CustomRnProject',
       needTs: true,
       cross: true,
       plugins: {},
@@ -353,4 +354,14 @@ test('test-rn', async () => {
 
   const pkg = require(path.resolve(cwd, name, 'package.json'))
   expect(pkg.devDependencies).toHaveProperty('@mpxjs/vue-cli-plugin-mpx')
+  expect(pkg.dependencies).not.toHaveProperty('react')
+  expect(pkg.dependencies).not.toHaveProperty('react-native')
+  expect(pkg.dependencies).toHaveProperty('react-native-reanimated', '3.16.7')
+  expect(pkg.dependencies).toHaveProperty('promise', '^8.3.0')
+  expect(pkg.dependencies).not.toHaveProperty('react-native-ble-manager')
+  expect(pkg.dependencies).not.toHaveProperty('react-native-wifi-reborn')
+  expect(pkg.scripts['serve:ios']).toContain('cd CustomRnProject')
+  const mpxConfig = require(path.resolve(cwd, name, 'mpx.config.js'))
+  expect(mpxConfig.pluginOptions.mpx.plugin.rnConfig.projectName).toBe('CustomRnProject')
+  expect(fs.readFileSync(path.resolve(cwd, name, 'tsconfig.json'), 'utf8')).toContain('"CustomRnProject"')
 })

--- a/packages/mpx-cli/__tests__/rn-create.spec.js
+++ b/packages/mpx-cli/__tests__/rn-create.spec.js
@@ -1,0 +1,89 @@
+const mockExeca = jest.fn()
+const mockInstall = jest.fn()
+const mockPackageManager = jest.fn(({ context, forcePackageManager }) => ({
+  bin: forcePackageManager,
+  context,
+  install: mockInstall
+}))
+
+jest.mock('@vue/cli-shared-utils', () => ({
+  chalk: { yellow: (message) => message },
+  execa: mockExeca,
+  hasYarn: () => false
+}))
+jest.mock('@vue/cli/lib/options', () => ({ loadOptions: () => ({}) }))
+jest.mock('@vue/cli/lib/util/ProjectPackageManager', () => mockPackageManager)
+
+const fs = require('fs-extra')
+const os = require('os')
+const path = require('path')
+const createPrompts = require('../lib/prompts')
+const { createRnProject, validateRnProjectName } = require('../lib/createRn')
+
+describe('React Native project name', () => {
+  let targetDir
+
+  beforeEach(() => {
+    targetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mpx-cli-rn-'))
+    mockExeca.mockImplementation(async (command, args, options) => {
+      const rnProjectPath = path.resolve(options.cwd, args[2])
+      fs.mkdirSync(rnProjectPath)
+      fs.writeJsonSync(path.resolve(rnProjectPath, 'package.json'), {
+        dependencies: {
+          react: '18.3.1',
+          'react-native': '0.77.2',
+          'react-native-reanimated': '3.16.7',
+          'react-native-ble-manager': '^12.4.4',
+          'react-native-wifi-reborn': '^4.13.6'
+        }
+      })
+      fs.writeFileSync(path.resolve(rnProjectPath, 'babel.config.js'), 'module.exports = {}')
+    })
+  })
+
+  afterEach(() => {
+    fs.removeSync(targetDir)
+    jest.clearAllMocks()
+  })
+
+  test('uses the mpx project name as the prompt default', () => {
+    const prompt = createPrompts('MyMpxProject').find(({ name }) => name === 'rnProjectName')
+
+    expect(prompt.default).toBe('MyMpxProject')
+    expect(prompt.when({ srcMode: 'wx', needRn: true })).toBe(true)
+    expect(prompt.when({ srcMode: 'wx', needRn: false })).toBe(false)
+  })
+
+  test('validates names using React Native identifier rules', () => {
+    expect(validateRnProjectName('CustomRnProject')).toBe(true)
+    expect(validateRnProjectName('_CustomRnProject')).toBe(true)
+    expect(validateRnProjectName('custom-rn-project')).not.toBe(true)
+    expect(validateRnProjectName('../CustomRnProject')).not.toBe(true)
+    expect(validateRnProjectName('$CustomRnProject')).not.toBe(true)
+    expect(validateRnProjectName('Custom$RnProject')).not.toBe(true)
+    expect(validateRnProjectName('React')).not.toBe(true)
+  })
+
+  test('creates and configures the requested project directory', async () => {
+    await createRnProject(targetDir, { packageManager: 'npm' }, 'CustomRnProject')
+
+    const initArgs = mockExeca.mock.calls[0][1]
+    expect(initArgs[0]).toBe('@react-native-community/cli@^19.0.0')
+    expect(initArgs.slice(1, 3)).toEqual(['init', 'CustomRnProject'])
+    expect(initArgs.slice(initArgs.indexOf('--version'), initArgs.indexOf('--version') + 2))
+      .toEqual(['--version', '0.77.2'])
+    expect(mockPackageManager).toHaveBeenCalledWith({
+      context: path.resolve(targetDir, 'CustomRnProject'),
+      forcePackageManager: 'npm'
+    })
+    const dependencies = fs.readJsonSync(path.resolve(targetDir, 'CustomRnProject/package.json')).dependencies
+    expect(dependencies).toHaveProperty('react', '18.3.1')
+    expect(dependencies).toHaveProperty('react-native', '0.77.2')
+    expect(dependencies).toHaveProperty('react-native-reanimated', '3.16.7')
+    expect(dependencies).toHaveProperty('react-native-ble-manager', '^12.4.4')
+    expect(dependencies).toHaveProperty('react-native-wifi-reborn', '^4.13.6')
+    expect(dependencies).toHaveProperty('react-native-svg', '^15.8.0')
+    expect(dependencies).toHaveProperty('react-native-vision-camera', '^4.7.3')
+    expect(mockInstall).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
+++ b/packages/mpx-cli/__tests__/rn-sourcemap.spec.js
@@ -543,13 +543,26 @@ describe('metro-mpx-sourcemap-middleware', () => {
 describe('RN project sourcemap generation config', () => {
   test('adds sourcemap dependencies and bundle scripts to RN package.json', () => {
     const pkg = {
-      dependencies: {},
+      dependencies: {
+        react: '18.3.1',
+        'react-native': '0.77.2',
+        'react-native-reanimated': '3.16.7',
+        'react-native-ble-manager': '^12.4.4',
+        'react-native-wifi-reborn': '^4.13.6'
+      },
       devDependencies: {},
       scripts: {}
     }
 
     applyRnPackageConfig(pkg)
 
+    expect(pkg.dependencies).toHaveProperty('react', '18.3.1')
+    expect(pkg.dependencies).toHaveProperty('react-native', '0.77.2')
+    expect(pkg.dependencies).toHaveProperty('react-native-reanimated', '3.16.7')
+    expect(pkg.dependencies).toHaveProperty('react-native-ble-manager', '^12.4.4')
+    expect(pkg.dependencies).toHaveProperty('react-native-wifi-reborn', '^4.13.6')
+    expect(pkg.dependencies).toHaveProperty('react-native-svg', '^15.8.0')
+    expect(pkg.dependencies).toHaveProperty('react-native-vision-camera', '^4.7.3')
     expect(pkg.devDependencies).toHaveProperty('source-map', '^0.7.6')
     expect(pkg.devDependencies).not.toHaveProperty('@jridgewell/remapping')
     expect(pkg.scripts['bundle:ios']).toContain('--sourcemap-output ./ios/main.jsbundle.map')

--- a/packages/mpx-cli/lib/create.js
+++ b/packages/mpx-cli/lib/create.js
@@ -20,9 +20,12 @@ const loadLocalPreset = require('@vue/cli/lib/util/loadLocalPreset')
 const { getPromptModules } = require('@vue/cli/lib/util/createTools')
 const { clearConsole } = require('@vue/cli/lib/util/clearConsole')
 const merge = require('lodash.merge')
-const prompts = require('./prompts')
+const createPrompts = require('./prompts')
 const builtInPreset = require('./preset')
-const { createRnProject } = require('./createRn')
+const {
+  createRnProject,
+  validateRnProjectName
+} = require('./createRn')
 const MpxCliPromptsKey = 'mpxCliPrompts'
 const PnpmShamefullyHoistConfigRegExp = /^shamefully-(hoist|flatten)=.*$/gm
 
@@ -255,7 +258,13 @@ async function resolveCliPreset (options) {
  * @returns
  */
 async function create (projectName, options, preset = null) {
+  const cwd = options.cwd || process.cwd()
+  const inCurrent = projectName === '.'
+  const name = inCurrent ? path.relative('../', cwd) : projectName
+  const targetDir = path.resolve(cwd, projectName || '.')
+
   // resolve preset
+  const prompts = createPrompts(name)
   let promptList = prompts
   if (!preset) {
     const cliPreset = await resolveCliPreset(options)
@@ -279,15 +288,18 @@ async function create (projectName, options, preset = null) {
     }
   })
 
+  if (preset.needRn) {
+    preset.rnProjectName = preset.rnProjectName || name
+    const validationResult = validateRnProjectName(preset.rnProjectName)
+    if (validationResult !== true) {
+      throw new Error(validationResult)
+    }
+  }
+
   // 设置代理
   if (options.proxy) {
     process.env.HTTP_PROXY = options.proxy
   }
-
-  const cwd = options.cwd || process.cwd()
-  const inCurrent = projectName === '.'
-  const name = inCurrent ? path.relative('../', cwd) : projectName
-  const targetDir = path.resolve(cwd, projectName || '.')
 
   const result = validateProjectName(name)
   if (!result.validForNewPackages) {
@@ -358,6 +370,7 @@ async function create (projectName, options, preset = null) {
       cross: preset.cross,
       needSSR: preset.needSSR,
       needRn: preset.needRn,
+      rnProjectName: preset.rnProjectName,
       name
     })
   })
@@ -419,7 +432,7 @@ async function create (projectName, options, preset = null) {
   })
 
   if (!process.env.VUE_CLI_TEST && preset.needRn) {
-    await createRnProject(targetDir, options)
+    await createRnProject(targetDir, options, preset.rnProjectName)
   }
 }
 

--- a/packages/mpx-cli/lib/createRn.js
+++ b/packages/mpx-cli/lib/createRn.js
@@ -21,10 +21,11 @@ const RN_DEP = {
   'react-native-safe-area-context': '^4.10.9',
   'react-native-ble-manager': '^12.4.4',
   'react-native-wifi-reborn': '^4.13.6',
+  'react-native-svg': '^15.8.0',
   react: '18.3.1',
   'react-native': '0.77.2',
   'react-native-video': '^6.11.0',
-  'react-native-vision-camera': '^5.0.10'
+  'react-native-vision-camera': '^4.7.3'
 }
 
 const RN_DEV_DEP = {
@@ -42,6 +43,8 @@ const RN_SOURCEMAP_SCRIPTS = [
   'compose-mpx-sourcemap.js',
   'metro-mpx-sourcemap-middleware.js'
 ].map((file) => path.resolve(__dirname, 'rn', file))
+
+const RN_PROJECT_NAME_REGEXP = /^[A-Z_][0-9A-Z_]*$/i
 
 const RN_METRO_CONFIG = `const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 const {enhanceMiddleware} = require('./scripts/metro-mpx-sourcemap-middleware');
@@ -100,8 +103,22 @@ function writeRnMetroConfig (rnProjectPath) {
   fs.writeFileSync(path.resolve(rnProjectPath, 'metro.config.js'), RN_METRO_CONFIG)
 }
 
-async function createRnProject (targetDir, options) {
-  const rnProjectPath = path.resolve(targetDir, 'ReactNativeProject')
+function validateRnProjectName (name) {
+  if (typeof name !== 'string' || !RN_PROJECT_NAME_REGEXP.test(name)) {
+    return 'React Native 项目名称必须以字母或 _ 开头，且只能包含字母、数字或 _'
+  }
+  if (name.toLowerCase() === 'react') {
+    return 'React Native 项目名称不能为 React'
+  }
+  return true
+}
+
+async function createRnProject (targetDir, options, rnProjectName = path.basename(targetDir)) {
+  const validationResult = validateRnProjectName(rnProjectName)
+  if (validationResult !== true) {
+    throw new Error(validationResult)
+  }
+  const rnProjectPath = path.resolve(targetDir, rnProjectName)
 
   const defaultPm = (hasYarn() ? 'yarn' : null) || 'npm'
   let packageManager = options.packageManager || loadOptions().packageManager || defaultPm
@@ -121,7 +138,7 @@ async function createRnProject (targetDir, options) {
     [
       '@react-native-community/cli@^19.0.0',
       'init',
-      'ReactNativeProject',
+      rnProjectName,
       '--version',
       '0.77.2',
       '--pm',
@@ -134,10 +151,10 @@ async function createRnProject (targetDir, options) {
     { stdio: 'inherit', cwd: targetDir }
   )
 
-  const pkgPath = path.resolve(targetDir, 'ReactNativeProject', 'package.json')
+  const pkgPath = path.resolve(rnProjectPath, 'package.json')
   updateJsonFile(pkgPath, applyRnPackageConfig)
 
-  const babelConfigPath = path.resolve(targetDir, 'ReactNativeProject', 'babel.config.js')
+  const babelConfigPath = path.resolve(rnProjectPath, 'babel.config.js')
   updateJsModule(babelConfigPath, config => {
     if (!config.plugins) {
       config.plugins = []
@@ -152,6 +169,8 @@ async function createRnProject (targetDir, options) {
 }
 
 module.exports.createRnProject = createRnProject
+module.exports.validateRnProjectName = validateRnProjectName
+module.exports.RN_DEP = RN_DEP
 module.exports.applyRnPackageConfig = applyRnPackageConfig
 module.exports.copyRnSourcemapScript = copyRnSourcemapScript
 module.exports.writeRnMetroConfig = writeRnMetroConfig

--- a/packages/mpx-cli/lib/prompts.js
+++ b/packages/mpx-cli/lib/prompts.js
@@ -1,6 +1,7 @@
 const prefix = '@mpxjs/vue-cli-plugin-mpx'
+const { validateRnProjectName } = require('./createRn')
 
-module.exports = [
+const prompts = [
   {
     name: 'srcMode',
     type: 'list',
@@ -22,6 +23,13 @@ module.exports = [
     message: '是否需要跨平台输出 React Native',
     type: 'confirm',
     default: false
+  },
+  {
+    name: 'rnProjectName',
+    when: ({ srcMode, needRn }) => srcMode === 'wx' && needRn === true,
+    message: '请输入 React Native 项目名称',
+    type: 'input',
+    validate: validateRnProjectName
   },
   {
     name: 'needSSR',
@@ -146,3 +154,9 @@ module.exports = [
     default: 'touristappid'
   }
 ]
+
+module.exports = function createPrompts (defaultRnProjectName) {
+  return prompts.map((prompt) => prompt.name === 'rnProjectName'
+    ? { ...prompt, default: defaultRnProjectName }
+    : prompt)
+}

--- a/packages/vue-cli-plugin-mpx-typescript/generator/index.js
+++ b/packages/vue-cli-plugin-mpx-typescript/generator/index.js
@@ -11,7 +11,8 @@ module.exports = function (api, options) {
 
   api.render('./template-tsconfig', {
     needTest: !!options.needUnitTest || !!options.needE2ETest,
-    needRn: !!options.needRn
+    needRn: !!options.needRn,
+    rnProjectName: options.rnProjectName || 'ReactNativeProject'
   })
 
   api.render((files) => delete files['jsconfig.json'])

--- a/packages/vue-cli-plugin-mpx-typescript/generator/template-tsconfig/tsconfig.json
+++ b/packages/vue-cli-plugin-mpx-typescript/generator/template-tsconfig/tsconfig.json
@@ -28,7 +28,7 @@
     "dist",
     "config",
     <%_ if(needRn) { _%>
-    "ReactNativeProject"
+    "<%= rnProjectName %>"
     <%_ } _%>
   ]
 }

--- a/packages/vue-cli-plugin-mpx/__tests__/rn-externals.spec.js
+++ b/packages/vue-cli-plugin-mpx/__tests__/rn-externals.spec.js
@@ -1,0 +1,21 @@
+const {
+  RN_EXTERNAL_DEPENDENCIES,
+  RN_EXTERNALS
+} = require('../config/rnExternals')
+const { RN_DEP } = require('../../mpx-cli/lib/createRn')
+
+test('RN externals match dependencies installed in the RN project', () => {
+  const dependencyNames = Object.keys(RN_DEP)
+  const subpathNames = [
+    'react/jsx-runtime',
+    'react-native-gesture-handler/DrawerLayout',
+    'react-native-gesture-handler/Swipeable',
+    'react-native-svg/css'
+  ]
+
+  expect(RN_EXTERNAL_DEPENDENCIES).toEqual(dependencyNames)
+  expect(Object.keys(RN_EXTERNALS)).toEqual([...dependencyNames, ...subpathNames])
+  Object.entries(RN_EXTERNALS).forEach(([request, external]) => {
+    expect(external).toBe(request)
+  })
+})

--- a/packages/vue-cli-plugin-mpx/commands/build/index.js
+++ b/packages/vue-cli-plugin-mpx/commands/build/index.js
@@ -56,7 +56,7 @@ module.exports.registerBuildCommand = function (api, options) {
             .then((...res) => {
               if (target !== 'web' && !options.disabledDefaultLinkFile) {
                 // web版本不需要symlink
-                symlinkTargetConfig(api, target, webpackConfigs[0])
+                symlinkTargetConfig(api, target, webpackConfigs[0], options)
               }
               resolve(...res)
             })

--- a/packages/vue-cli-plugin-mpx/commands/serve/mp.js
+++ b/packages/vue-cli-plugin-mpx/commands/serve/mp.js
@@ -17,7 +17,7 @@ module.exports.serveMp = async function serveMp (api, options, args) {
       handleWebpackDone(err, stats, true, options, webpackConfigs[0])
         .then((...res) => {
           if (!options.disabledDefaultLinkFile) {
-            symlinkTargetConfig(api, target, webpackConfigs[0])
+            symlinkTargetConfig(api, target, webpackConfigs[0], options)
           }
           resolve(...res)
         })

--- a/packages/vue-cli-plugin-mpx/config/base.js
+++ b/packages/vue-cli-plugin-mpx/config/base.js
@@ -14,6 +14,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
 const resolveClientEnv = require('@vue/cli-service/lib/util/resolveClientEnv')
 const { getReporter } = require('../utils/reporter')
+const { RN_EXTERNALS } = require('./rnExternals')
 
 /**
  * 强制改chain-webpack的vue style loader use的名字
@@ -374,45 +375,7 @@ function addRnWebpackConfig (api, options, config, target) {
   config.resolve.extensions.add('.tsx').add('.jsx')
   config.output.publicPath('/')
   config.output.filename('[name].js')
-  config.externals({
-    'react-native': 'react-native',
-    react: 'react',
-    '@react-native-masked-view/masked-view':
-      '@react-native-masked-view/masked-view',
-    'react-native-reanimated': 'react-native-reanimated',
-    'react-native-gesture-handler': 'react-native-gesture-handler',
-    'react-native-gesture-handler/DrawerLayout':
-      'react-native-gesture-handler/DrawerLayout',
-    'react-native-gesture-handler/Swipeable':
-      'react-native-gesture-handler/Swipeable',
-    '@ant-design/icons-react-native': '@ant-design/icons-react-native',
-    '@d11/react-native-fast-image': '@d11/react-native-fast-image',
-    'react-native-safe-area-context': 'react-native-safe-area-context',
-    'react-native-collapsible': 'react-native-collapsible',
-    'react-native-modal-popover': 'react-native-modal-popover',
-    'react/jsx-runtime': 'react/jsx-runtime',
-    '@react-navigation/native': '@react-navigation/native',
-    '@react-navigation/native-stack': '@react-navigation/native-stack',
-    '@react-navigation/stack': '@react-navigation/stack',
-    '@react-navigation/elements': '@react-navigation/elements',
-    '@react-native-async-storage/async-storage':
-      '@react-native-async-storage/async-storage',
-    '@react-native-clipboard/clipboard': '@react-native-clipboard/clipboard',
-    '@react-native-community/netinfo': '@react-native-community/netinfo',
-    'react-native-device-info': 'react-native-device-info',
-    'react-native-root-siblings': 'react-native-root-siblings',
-    'react-native-maps': 'react-native-maps',
-    '@ant-design/react-native': '@ant-design/react-native',
-    'expo-brightness': 'expo-brightness',
-    'expo-clipboard': 'expo-clipboard',
-    'react-native-webview': 'react-native-webview',
-    'react-native-get-location': 'react-native-get-location',
-    'react-native-linear-gradient': 'react-native-linear-gradient',
-    'react-native-haptic-feedback': 'react-native-haptic-feedback',
-    'react-native-svg/css': 'react-native-svg/css',
-    'react-native-vision-camera': 'react-native-vision-camera',
-    'react-native-ble-manager': 'react-native-ble-manager'
-  })
+  config.externals(RN_EXTERNALS)
 }
 
 /**

--- a/packages/vue-cli-plugin-mpx/config/rnExternals.js
+++ b/packages/vue-cli-plugin-mpx/config/rnExternals.js
@@ -1,0 +1,37 @@
+const RN_EXTERNAL_DEPENDENCIES = [
+  '@d11/react-native-fast-image',
+  '@react-native-async-storage/async-storage',
+  '@react-native-community/netinfo',
+  '@react-navigation/native',
+  '@react-navigation/native-stack',
+  'react-native-device-info',
+  'react-native-gesture-handler',
+  'react-native-get-location',
+  'react-native-haptic-feedback',
+  'react-native-linear-gradient',
+  'react-native-reanimated',
+  'react-native-screens',
+  'react-native-webview',
+  'react-native-safe-area-context',
+  'react-native-ble-manager',
+  'react-native-wifi-reborn',
+  'react-native-svg',
+  'react',
+  'react-native',
+  'react-native-video',
+  'react-native-vision-camera'
+]
+
+const RN_EXTERNALS = [
+  ...RN_EXTERNAL_DEPENDENCIES,
+  'react/jsx-runtime',
+  'react-native-gesture-handler/DrawerLayout',
+  'react-native-gesture-handler/Swipeable',
+  'react-native-svg/css'
+].reduce((externals, name) => {
+  externals[name] = name
+  return externals
+}, {})
+
+module.exports.RN_EXTERNAL_DEPENDENCIES = RN_EXTERNAL_DEPENDENCIES
+module.exports.RN_EXTERNALS = RN_EXTERNALS

--- a/packages/vue-cli-plugin-mpx/generator/index.js
+++ b/packages/vue-cli-plugin-mpx/generator/index.js
@@ -1,4 +1,6 @@
 module.exports = function (api, options) {
+  const rnProjectName = options.rnProjectName || 'ReactNativeProject'
+
   require('./base')(api, options)
   require('./static')(api, options)
   require('./babel')(api, options)
@@ -47,15 +49,12 @@ module.exports = function (api, options) {
 
   if (options.needRn) {
     mpxPluginConfig.rnConfig = {
-      projectName: 'ReactNativeProject'
+      projectName: rnProjectName
     }
     api.extendPackage({
       dependencies: {
-        react: '18.3.1',
-        'react-native': '0.77.2',
         'react-native-reanimated': '3.16.7',
-        'react-native-ble-manager': '^12.4.4',
-        'react-native-wifi-reborn': '^4.13.6'
+        promise: '^8.3.0'
       }
     })
   }
@@ -160,10 +159,10 @@ module.exports = function (api, options) {
   if (options.needRn) {
     api.extendPackage({
       scripts: {
-        'serve:ios': 'cd ReactNativeProject && npm run ios && cd .. && mpx-cli-service serve --targets=ios',
-        'build:ios': 'mpx-cli-service build --targets=ios && cd ReactNativeProject && npm run bundle:ios',
-        'serve:android': 'cd ReactNativeProject && npm run android && cd .. && mpx-cli-service serve --targets=android',
-        'build:android': 'mpx-cli-service build --targets=android && cd ReactNativeProject && npm run bundle:android'
+        'serve:ios': `cd ${rnProjectName} && npm run ios && cd .. && mpx-cli-service serve --targets=ios`,
+        'build:ios': `mpx-cli-service build --targets=ios && cd ${rnProjectName} && npm run bundle:ios`,
+        'serve:android': `cd ${rnProjectName} && npm run android && cd .. && mpx-cli-service serve --targets=android`,
+        'build:android': `mpx-cli-service build --targets=android && cd ${rnProjectName} && npm run bundle:android`
       }
     })
   }

--- a/packages/vue-cli-plugin-mpx/utils/symlink.js
+++ b/packages/vue-cli-plugin-mpx/utils/symlink.js
@@ -22,8 +22,9 @@ function copyDirSync (src, dest) {
  * @param { import('@vue/cli-service').PluginAPI } api
  * @param { import('@mpxjs/cli-shared-utils').Target } target
  * @param { import('webpack').Configuration } webpackConfig
+ * @param { object } options
  */
-module.exports.symlinkTargetConfig = function (api, target, webpackConfig) {
+module.exports.symlinkTargetConfig = function (api, target, webpackConfig, options) {
   const targetConfigFiles = MODE_CONFIG_FILES_MAP[target.mode] || []
   let outputPath = webpackConfig.output.path
   targetConfigFiles.forEach((v) => {
@@ -47,7 +48,9 @@ module.exports.symlinkTargetConfig = function (api, target, webpackConfig) {
   try {
     const isRn = (target.mode === 'android') | (target.mode === 'ios') | (target.mode === 'harmony')
     if (isRn) {
-      const rnProjectPath = path.resolve(process.cwd(), 'ReactNativeProject')
+      const mpxOptions = options && options.pluginOptions && options.pluginOptions.mpx
+      const rnConfig = mpxOptions && mpxOptions.plugin && mpxOptions.plugin.rnConfig
+      const rnProjectPath = path.resolve(process.cwd(), (rnConfig && rnConfig.projectName) || 'ReactNativeProject')
       const items = fs.readdirSync(outputPath)
       items.forEach((item) => {
         const src = path.resolve(outputPath, item)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * React Native projects can now use a custom project name during creation.
  * Added project-name validation with sensible defaults and clearer handling of invalid names.
  * Generated React Native configurations, scripts, TypeScript settings, and paths now adapt to the selected project name.
  * Added React Native dependency support for `react-native-svg` and updated Vision Camera.

* **Bug Fixes**
  * Improved dependency preservation and external-module handling for React Native builds.
  * Ensured build and serve workflows correctly locate custom React Native projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->